### PR TITLE
Update minimum Node version to 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        node: [ '18', '20', '22' ]
+        node: [ '20', '22' ]
     name: Node ${{ matrix.node }} (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Foundation is the most advanced responsive front-end framework in the world. Qui
 
 ### Documentation
 
-To run the documentation locally on your machine, you need [Node.js](https://nodejs.org/en/) installed on your computer. (Your Node.js version must be a **minimum of 18**). Run these commands to set up the documentation:
+To run the documentation locally on your machine, you need [Node.js](https://nodejs.org/en/) installed on your computer. (Your Node.js version must be a **minimum of 20**). Run these commands to set up the documentation:
 
 ```bash
 # Install

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "lodash.template": ">=4.5.0"
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=20.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump `engines.node` to Node 20
- document Node 20 requirement in the README
- test on Node 20 and 22 in CI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862f5b612bc8323bda03725cf114e35