### PR TITLE
Improve tooltip events and reveal cleanup

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -48,7 +48,6 @@ class Reveal extends Plugin {
     MediaQuery._init();
     this.id = this.$element.attr('id');
     this.isActive = false;
-    this.cached = {mq: MediaQuery.current};
 
     this.$anchor = $(`[data-open="${this.id}"]`).length ? $(`[data-open="${this.id}"]`) : $(`[data-toggle="${this.id}"]`);
     this.$anchor.attr({
@@ -102,7 +101,6 @@ class Reveal extends Plugin {
 
   /**
    * Updates position of modal
-   * TODO:  Figure out if we actually need to cache these values or if it doesn't matter
    * @private
    */
   _updatePosition() {
@@ -190,6 +188,7 @@ class Reveal extends Plugin {
   */
   _disableScroll(scrollTop) {
     scrollTop = scrollTop || $(window).scrollTop();
+    this._scrollTop = scrollTop;
     if ($(document).height() > $(window).height()) {
       $("html")
         .css("top", -scrollTop);
@@ -201,12 +200,15 @@ class Reveal extends Plugin {
   * @param {number} scrollTop - Scroll to restore, html "top" property by default (as set by `_disableScroll`)
   */
   _enableScroll(scrollTop) {
-    scrollTop = scrollTop || parseInt($("html").css("top"), 10);
+    if (typeof scrollTop !== 'number') {
+      scrollTop = this._scrollTop || parseInt($("html").css("top"), 10);
+    }
     if ($(document).height() > $(window).height()) {
       $("html")
         .css("top", "");
       $(window).scrollTop(-scrollTop);
     }
+    this._scrollTop = null;
   }
 
 
@@ -433,11 +435,6 @@ class Reveal extends Plugin {
 
     function finishUp() {
 
-      // Get the current top before the modal is closed and restore the scroll after.
-      // TODO: use component properties instead of HTML properties
-      // See https://github.com/foundation/foundation-sites/pull/10786
-      const scrollTop = parseInt($("html").css("top"), 10);
-
       if ($('.reveal:visible').length  === 0) {
         _this._removeGlobalClasses(); // also remove .is-reveal-open from the html element when there is no opened reveal
       }
@@ -447,7 +444,7 @@ class Reveal extends Plugin {
       _this.$element.attr('aria-hidden', true);
 
       if ($('.reveal:visible').length  === 0) {
-        _this._enableScroll(scrollTop);
+        _this._enableScroll();
       }
 
       /**

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -185,9 +185,8 @@ class Tooltip extends Positionable {
   }
 
   /**
-   * adds event listeners for the tooltip and its anchor
-   * TODO combine some of the listeners like focus and mouseenter, etc.
-   * @private
+  * adds event listeners for the tooltip and its anchor
+  * @private
    */
   _events() {
     const _this = this;
@@ -197,56 +196,9 @@ class Tooltip extends Positionable {
     // `disableForTouch: Fully disable the tooltip on touch devices
     if (hasTouch && this.options.disableForTouch) return;
 
-    if (!this.options.disableHover) {
-      this.$element
-      .on('mouseenter.zf.tooltip', () => {
-        if (!_this.isActive) {
-          _this.timeout = setTimeout(() => {
-            _this.show();
-          }, _this.options.hoverDelay);
-        }
-      })
-      .on('mouseleave.zf.tooltip', ignoreMousedisappear(() => {
-        clearTimeout(_this.timeout);
-        if (!isFocus || (_this.isClick && !_this.options.clickOpen)) {
-          _this.hide();
-        }
-      }));
-    }
-
-    if (hasTouch) {
-      this.$element
-      .on('tap.zf.tooltip touchend.zf.tooltip', () => {
-        _this.isActive ? _this.hide() : _this.show();
-      });
-    }
-
-    if (this.options.clickOpen) {
-      this.$element.on('mousedown.zf.tooltip', () => {
-        if (_this.isClick) {
-          //_this.hide();
-          // _this.isClick = false;
-        } else {
-          _this.isClick = true;
-          if ((_this.options.disableHover || !_this.$element.attr('tabindex')) && !_this.isActive) {
-            _this.show();
-          }
-        }
-      });
-    } else {
-      this.$element.on('mousedown.zf.tooltip', () => {
-        _this.isClick = true;
-      });
-    }
-
-    this.$element.on({
-      // 'toggle.zf.trigger': this.toggle.bind(this),
-      // 'close.zf.trigger': this.hide.bind(this)
-      'close.zf.trigger': this.hide.bind(this)
-    });
-
-    this.$element
-      .on('focus.zf.tooltip', () => {
+    const events = {
+      'close.zf.trigger': this.hide.bind(this),
+      'focus.zf.tooltip': () => {
         isFocus = true;
         if (_this.isClick) {
           // If we're not showing open on clicks, we need to pretend a click-launched focus isn't
@@ -256,19 +208,65 @@ class Tooltip extends Positionable {
         } else {
           _this.show();
         }
-      })
-
-      .on('focusout.zf.tooltip', () => {
+      },
+      'focusout.zf.tooltip': () => {
         isFocus = false;
         _this.isClick = false;
         _this.hide();
-      })
-
-      .on('resizeme.zf.trigger', () => {
+      },
+      'resizeme.zf.trigger': () => {
         if (_this.isActive) {
           _this._setPosition();
         }
+      }
+    };
+
+    if (!this.options.disableHover) {
+      events['mouseenter.zf.tooltip'] = () => {
+        if (!_this.isActive) {
+          _this.timeout = setTimeout(() => {
+            _this.show();
+          }, _this.options.hoverDelay);
+        }
+      };
+      events['mouseleave.zf.tooltip'] = ignoreMousedisappear(() => {
+        clearTimeout(_this.timeout);
+        if (!isFocus || (_this.isClick && !_this.options.clickOpen)) {
+          _this.hide();
+        }
       });
+    }
+
+    if (hasTouch) {
+      events['tap.zf.tooltip touchend.zf.tooltip'] = () => {
+        _this.isActive ? _this.hide() : _this.show();
+      };
+    }
+
+    if (this.options.clickOpen) {
+      events['mousedown.zf.tooltip'] = () => {
+        if (_this.isClick) {
+          // noop
+        } else {
+          _this.isClick = true;
+          if ((_this.options.disableHover || !_this.$element.attr('tabindex')) && !_this.isActive) {
+            _this.show();
+          }
+        }
+      };
+    } else {
+      events['mousedown.zf.tooltip'] = () => {
+        _this.isClick = true;
+      };
+    }
+
+    this.$element.on(events);
+
+    $(window).on(`resize.zf.tooltip-${this.id}`, () => {
+      if (_this.isActive) {
+        _this._setPosition();
+      }
+    });
   }
 
   /**
@@ -295,6 +293,7 @@ class Tooltip extends Positionable {
                  .removeAttr('aria-describedby data-disable-hover data-resize data-toggle data-tooltip data-yeti-box');
 
     this.template.remove();
+    $(window).off(`resize.zf.tooltip-${this.id}`);
   }
 }
 
@@ -456,8 +455,6 @@ Tooltip.defaults = {
   allowHtml: false
 };
 
-/**
- * TODO utilize resize event trigger
- */
+
 
 export {Tooltip};


### PR DESCRIPTION
## Summary
- consolidate tooltip event listeners
- reposition tooltip on window resize
- clean reveal scroll handling
- remove unused caching and outdated TODOs

## Testing
- `yarn test:javascript:units`

------
https://chatgpt.com/codex/tasks/task_e_68630cbd06fc8323ae602213781f336f